### PR TITLE
Set sharedConfiguration in release directory

### DIFF
--- a/repository/cs-studio.p2.inf
+++ b/repository/cs-studio.p2.inf
@@ -8,4 +8,7 @@ instructions.configure=\
   
 # See https://bugs.eclipse.org/bugs/show_bug.cgi?id=231557
 instructions.install = \
-  setProgramProperty(propName:osgi.instance.area.default,propValue:@user.home/.cs-studio); 
+  setProgramProperty(propName:osgi.instance.area.default,propValue:@user.home/.cs-studio);\
+  setProgramProperty(propName:osgi.sharedConfiguration.area,propValue:file\:configuration);\
+  setProgramProperty(propName:osgi.sharedConfiguration.area.readOnly,propValue:true);\
+  setProgramProperty(propName:osgi.configuration.cascaded,propValue:true);


### PR DESCRIPTION
Attempted fix for the issues requiring the $user/.eclipse/configuration directory to be emptied before a new nightly build can be executed.

(corresponding change made to build script to execute cs-studio -initialize) 