### PR TITLE
Add right click actions to show/hide toolbar on Dawn XYGraph

### DIFF
--- a/plugins/org.csstudio.opibuilder.widgets.dawn/META-INF/MANIFEST.MF
+++ b/plugins/org.csstudio.opibuilder.widgets.dawn/META-INF/MANIFEST.MF
@@ -18,3 +18,4 @@ Require-Bundle: org.eclipse.ui,
  org.diirt.vtype;bundle-version="3.0.1"
 Bundle-RequiredExecutionEnvironment: JavaSE-1.7
 Bundle-ActivationPolicy: lazy
+Export-Package: org.csstudio.opibuilder.widgets.dawn.xygraph

--- a/plugins/org.csstudio.opibuilder.widgets.dawn/plugin.xml
+++ b/plugins/org.csstudio.opibuilder.widgets.dawn/plugin.xml
@@ -12,5 +12,29 @@
             typeId="org.csstudio.opibuilder.widgets.dawn.xygraph">
       </widget>
    </extension>
+   <extension
+         point="org.eclipse.ui.popupMenus">
+      <objectContribution
+            adaptable="false"
+            id="org.csstudio.opibuilder.widgets.dawn.xygraph"
+            objectClass="org.csstudio.opibuilder.widgets.dawn.xygraph.DawnXYGraphEditPart">
+         <action
+               class="org.csstudio.opibuilder.widgets.dawn.actions.ShowXYGraphToolbarAction"
+               enablesFor="1"
+               id="org.csstudio.opibuilder.widgets.dawn.showToolbarAction"
+               label="Show/Hide Graph Toolbar"
+               menubarPath="xygraph"
+               tooltip="Show/Hide XY-Graph Toolbar">
+         </action>
+         <action
+               class="org.csstudio.opibuilder.widgets.dawn.actions.ClearXYGraphAction"
+               enablesFor="1"
+               id="org.csstudio.opibuilder.widgets.dawn.clearGraphAction"
+               label="Clear Graph"
+               menubarPath="xygraph"
+               tooltip="Clear Graph">
+         </action>
+      </objectContribution>
+   </extension>
 
 </plugin>

--- a/plugins/org.csstudio.opibuilder.widgets.dawn/src/org/csstudio/opibuilder/widgets/dawn/actions/AbstractXYGraphTargetAction.java
+++ b/plugins/org.csstudio.opibuilder.widgets.dawn/src/org/csstudio/opibuilder/widgets/dawn/actions/AbstractXYGraphTargetAction.java
@@ -3,7 +3,7 @@ package org.csstudio.opibuilder.widgets.dawn.actions;
 import org.csstudio.opibuilder.actions.AbstractWidgetTargetAction;
 import org.csstudio.opibuilder.widgets.dawn.xygraph.DawnXYGraphEditPart;
 
-public abstract class AbstractXYGraphWidgetTargetAction extends AbstractWidgetTargetAction {
+public abstract class AbstractXYGraphTargetAction extends AbstractWidgetTargetAction {
 
     /**
      * Gets the widget models of all currently selected EditParts.

--- a/plugins/org.csstudio.opibuilder.widgets.dawn/src/org/csstudio/opibuilder/widgets/dawn/actions/AbstractXYGraphTargetAction.java
+++ b/plugins/org.csstudio.opibuilder.widgets.dawn/src/org/csstudio/opibuilder/widgets/dawn/actions/AbstractXYGraphTargetAction.java
@@ -6,7 +6,7 @@ import org.csstudio.opibuilder.widgets.dawn.xygraph.DawnXYGraphEditPart;
 public abstract class AbstractXYGraphTargetAction extends AbstractWidgetTargetAction {
 
     /**
-     * Gets the widget models of all currently selected EditParts.
+     * Gets the widget model of the currently selected DawnXYGraphEditPart.
      *
      * @return the currently selected DawnXYGraphEditPart
      */

--- a/plugins/org.csstudio.opibuilder.widgets.dawn/src/org/csstudio/opibuilder/widgets/dawn/actions/AbstractXYGraphWidgetTargetAction.java
+++ b/plugins/org.csstudio.opibuilder.widgets.dawn/src/org/csstudio/opibuilder/widgets/dawn/actions/AbstractXYGraphWidgetTargetAction.java
@@ -1,0 +1,16 @@
+package org.csstudio.opibuilder.widgets.dawn.actions;
+
+import org.csstudio.opibuilder.actions.AbstractWidgetTargetAction;
+import org.csstudio.opibuilder.widgets.dawn.xygraph.DawnXYGraphEditPart;
+
+public abstract class AbstractXYGraphWidgetTargetAction extends AbstractWidgetTargetAction {
+
+    /**
+     * Gets the widget models of all currently selected EditParts.
+     *
+     * @return the currently selected DawnXYGraphEditPart
+     */
+    protected final DawnXYGraphEditPart getSelectedXYGraph() {
+        return (DawnXYGraphEditPart)selection.getFirstElement();
+    }
+}

--- a/plugins/org.csstudio.opibuilder.widgets.dawn/src/org/csstudio/opibuilder/widgets/dawn/actions/ClearXYGraphAction.java
+++ b/plugins/org.csstudio.opibuilder.widgets.dawn/src/org/csstudio/opibuilder/widgets/dawn/actions/ClearXYGraphAction.java
@@ -9,8 +9,8 @@ package org.csstudio.opibuilder.widgets.dawn.actions;
 
 import org.eclipse.jface.action.IAction;
 
-/**Clear XY Graph.
- *
+/**
+ * Clear XY Graph.
  */
 public class ClearXYGraphAction extends AbstractXYGraphTargetAction {
 

--- a/plugins/org.csstudio.opibuilder.widgets.dawn/src/org/csstudio/opibuilder/widgets/dawn/actions/ClearXYGraphAction.java
+++ b/plugins/org.csstudio.opibuilder.widgets.dawn/src/org/csstudio/opibuilder/widgets/dawn/actions/ClearXYGraphAction.java
@@ -13,7 +13,7 @@ import org.eclipse.jface.action.IAction;
  * @author Xihui Chen
  *
  */
-public class ClearXYGraphAction extends AbstractXYGraphWidgetTargetAction {
+public class ClearXYGraphAction extends AbstractXYGraphTargetAction {
 
     public void run(IAction action) {
         getSelectedXYGraph().clearGraph();

--- a/plugins/org.csstudio.opibuilder.widgets.dawn/src/org/csstudio/opibuilder/widgets/dawn/actions/ClearXYGraphAction.java
+++ b/plugins/org.csstudio.opibuilder.widgets.dawn/src/org/csstudio/opibuilder/widgets/dawn/actions/ClearXYGraphAction.java
@@ -10,7 +10,7 @@ package org.csstudio.opibuilder.widgets.dawn.actions;
 import org.eclipse.jface.action.IAction;
 
 /**Clear XY Graph.
- * @author Xihui Chen
+ * @author Matthew Furseman
  *
  */
 public class ClearXYGraphAction extends AbstractXYGraphTargetAction {

--- a/plugins/org.csstudio.opibuilder.widgets.dawn/src/org/csstudio/opibuilder/widgets/dawn/actions/ClearXYGraphAction.java
+++ b/plugins/org.csstudio.opibuilder.widgets.dawn/src/org/csstudio/opibuilder/widgets/dawn/actions/ClearXYGraphAction.java
@@ -7,27 +7,16 @@
  ******************************************************************************/
 package org.csstudio.opibuilder.widgets.dawn.actions;
 
-import org.csstudio.opibuilder.actions.AbstractWidgetTargetAction;
-import org.csstudio.opibuilder.widgets.dawn.xygraph.DawnXYGraphEditPart;
 import org.eclipse.jface.action.IAction;
 
 /**Clear XY Graph.
  * @author Xihui Chen
  *
  */
-public class ClearXYGraphAction extends AbstractWidgetTargetAction {
+public class ClearXYGraphAction extends AbstractXYGraphWidgetTargetAction {
 
     public void run(IAction action) {
         getSelectedXYGraph().clearGraph();
 
-    }
-
-    /**
-     * Gets the widget models of all currently selected EditParts.
-     *
-     * @return the currently selected DawnXYGraphEditPart
-     */
-    protected final DawnXYGraphEditPart getSelectedXYGraph() {
-        return (DawnXYGraphEditPart)selection.getFirstElement();
     }
 }

--- a/plugins/org.csstudio.opibuilder.widgets.dawn/src/org/csstudio/opibuilder/widgets/dawn/actions/ClearXYGraphAction.java
+++ b/plugins/org.csstudio.opibuilder.widgets.dawn/src/org/csstudio/opibuilder/widgets/dawn/actions/ClearXYGraphAction.java
@@ -1,0 +1,33 @@
+/*******************************************************************************
+ * Copyright (c) 2010 Oak Ridge National Laboratory.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ ******************************************************************************/
+package org.csstudio.opibuilder.widgets.dawn.actions;
+
+import org.csstudio.opibuilder.actions.AbstractWidgetTargetAction;
+import org.csstudio.opibuilder.widgets.dawn.xygraph.DawnXYGraphEditPart;
+import org.eclipse.jface.action.IAction;
+
+/**Clear XY Graph.
+ * @author Xihui Chen
+ *
+ */
+public class ClearXYGraphAction extends AbstractWidgetTargetAction {
+
+    public void run(IAction action) {
+        getSelectedXYGraph().clearGraph();
+
+    }
+
+    /**
+     * Gets the widget models of all currently selected EditParts.
+     *
+     * @return a list with all widget models that are currently selected
+     */
+    protected final DawnXYGraphEditPart getSelectedXYGraph() {
+        return (DawnXYGraphEditPart)selection.getFirstElement();
+    }
+}

--- a/plugins/org.csstudio.opibuilder.widgets.dawn/src/org/csstudio/opibuilder/widgets/dawn/actions/ClearXYGraphAction.java
+++ b/plugins/org.csstudio.opibuilder.widgets.dawn/src/org/csstudio/opibuilder/widgets/dawn/actions/ClearXYGraphAction.java
@@ -25,7 +25,7 @@ public class ClearXYGraphAction extends AbstractWidgetTargetAction {
     /**
      * Gets the widget models of all currently selected EditParts.
      *
-     * @return a list with all widget models that are currently selected
+     * @return the currently selected DawnXYGraphEditPart
      */
     protected final DawnXYGraphEditPart getSelectedXYGraph() {
         return (DawnXYGraphEditPart)selection.getFirstElement();

--- a/plugins/org.csstudio.opibuilder.widgets.dawn/src/org/csstudio/opibuilder/widgets/dawn/actions/ClearXYGraphAction.java
+++ b/plugins/org.csstudio.opibuilder.widgets.dawn/src/org/csstudio/opibuilder/widgets/dawn/actions/ClearXYGraphAction.java
@@ -10,7 +10,6 @@ package org.csstudio.opibuilder.widgets.dawn.actions;
 import org.eclipse.jface.action.IAction;
 
 /**Clear XY Graph.
- * @author Matthew Furseman
  *
  */
 public class ClearXYGraphAction extends AbstractXYGraphTargetAction {

--- a/plugins/org.csstudio.opibuilder.widgets.dawn/src/org/csstudio/opibuilder/widgets/dawn/actions/ShowXYGraphToolbarAction.java
+++ b/plugins/org.csstudio.opibuilder.widgets.dawn/src/org/csstudio/opibuilder/widgets/dawn/actions/ShowXYGraphToolbarAction.java
@@ -34,7 +34,7 @@ public class ShowXYGraphToolbarAction extends AbstractWidgetTargetAction {
     /**
      * Gets the widget models of all currently selected EditParts.
      *
-     * @return a list with all widget models that are currently selected
+     * @return the currently selected DawnXYGraphEditPart
      */
     protected final DawnXYGraphEditPart getSelectedXYGraph() {
         return (DawnXYGraphEditPart)selection.getFirstElement();

--- a/plugins/org.csstudio.opibuilder.widgets.dawn/src/org/csstudio/opibuilder/widgets/dawn/actions/ShowXYGraphToolbarAction.java
+++ b/plugins/org.csstudio.opibuilder.widgets.dawn/src/org/csstudio/opibuilder/widgets/dawn/actions/ShowXYGraphToolbarAction.java
@@ -19,13 +19,10 @@ import org.eclipse.jface.action.IAction;
  */
 public class ShowXYGraphToolbarAction extends AbstractXYGraphWidgetTargetAction {
 
-
-
     public void run(IAction action) {
         Command command = new SetWidgetPropertyCommand(
                 getSelectedXYGraph().getWidgetModel(), XYGraphModel.PROP_SHOW_TOOLBAR,
                 !getSelectedXYGraph().getWidgetModel().isShowToolbar());
         execute(command);
-
     }
 }

--- a/plugins/org.csstudio.opibuilder.widgets.dawn/src/org/csstudio/opibuilder/widgets/dawn/actions/ShowXYGraphToolbarAction.java
+++ b/plugins/org.csstudio.opibuilder.widgets.dawn/src/org/csstudio/opibuilder/widgets/dawn/actions/ShowXYGraphToolbarAction.java
@@ -7,9 +7,7 @@
  ******************************************************************************/
 package org.csstudio.opibuilder.widgets.dawn.actions;
 
-import org.csstudio.opibuilder.actions.AbstractWidgetTargetAction;
 import org.csstudio.opibuilder.commands.SetWidgetPropertyCommand;
-import org.csstudio.opibuilder.widgets.dawn.xygraph.DawnXYGraphEditPart;
 import org.csstudio.opibuilder.widgets.model.XYGraphModel;
 import org.eclipse.gef.commands.Command;
 import org.eclipse.jface.action.IAction;
@@ -19,7 +17,7 @@ import org.eclipse.jface.action.IAction;
  * @author Xihui Chen
  *
  */
-public class ShowXYGraphToolbarAction extends AbstractWidgetTargetAction {
+public class ShowXYGraphToolbarAction extends AbstractXYGraphWidgetTargetAction {
 
 
 
@@ -29,14 +27,5 @@ public class ShowXYGraphToolbarAction extends AbstractWidgetTargetAction {
                 !getSelectedXYGraph().getWidgetModel().isShowToolbar());
         execute(command);
 
-    }
-
-    /**
-     * Gets the widget models of all currently selected EditParts.
-     *
-     * @return the currently selected DawnXYGraphEditPart
-     */
-    protected final DawnXYGraphEditPart getSelectedXYGraph() {
-        return (DawnXYGraphEditPart)selection.getFirstElement();
     }
 }

--- a/plugins/org.csstudio.opibuilder.widgets.dawn/src/org/csstudio/opibuilder/widgets/dawn/actions/ShowXYGraphToolbarAction.java
+++ b/plugins/org.csstudio.opibuilder.widgets.dawn/src/org/csstudio/opibuilder/widgets/dawn/actions/ShowXYGraphToolbarAction.java
@@ -14,9 +14,8 @@ import org.eclipse.gef.commands.Command;
 import org.eclipse.jface.action.IAction;
 
 
-/**Show/Hide XYGraph Toolbar
- * @author Matthew Furseman
- *
+/**
+ * Show/Hide XYGraph Toolbar
  */
 public class ShowXYGraphToolbarAction extends AbstractXYGraphTargetAction {
 

--- a/plugins/org.csstudio.opibuilder.widgets.dawn/src/org/csstudio/opibuilder/widgets/dawn/actions/ShowXYGraphToolbarAction.java
+++ b/plugins/org.csstudio.opibuilder.widgets.dawn/src/org/csstudio/opibuilder/widgets/dawn/actions/ShowXYGraphToolbarAction.java
@@ -17,7 +17,7 @@ import org.eclipse.jface.action.IAction;
  * @author Xihui Chen
  *
  */
-public class ShowXYGraphToolbarAction extends AbstractXYGraphWidgetTargetAction {
+public class ShowXYGraphToolbarAction extends AbstractXYGraphTargetAction {
 
     public void run(IAction action) {
         Command command = new SetWidgetPropertyCommand(

--- a/plugins/org.csstudio.opibuilder.widgets.dawn/src/org/csstudio/opibuilder/widgets/dawn/actions/ShowXYGraphToolbarAction.java
+++ b/plugins/org.csstudio.opibuilder.widgets.dawn/src/org/csstudio/opibuilder/widgets/dawn/actions/ShowXYGraphToolbarAction.java
@@ -14,7 +14,7 @@ import org.eclipse.jface.action.IAction;
 
 
 /**Show/Hide XYGraph Toolbar
- * @author Xihui Chen
+ * @author Matthew Furseman
  *
  */
 public class ShowXYGraphToolbarAction extends AbstractXYGraphTargetAction {

--- a/plugins/org.csstudio.opibuilder.widgets.dawn/src/org/csstudio/opibuilder/widgets/dawn/actions/ShowXYGraphToolbarAction.java
+++ b/plugins/org.csstudio.opibuilder.widgets.dawn/src/org/csstudio/opibuilder/widgets/dawn/actions/ShowXYGraphToolbarAction.java
@@ -8,6 +8,7 @@
 package org.csstudio.opibuilder.widgets.dawn.actions;
 
 import org.csstudio.opibuilder.commands.SetWidgetPropertyCommand;
+import org.csstudio.opibuilder.widgets.dawn.xygraph.DawnXYGraphModel;
 import org.csstudio.opibuilder.widgets.model.XYGraphModel;
 import org.eclipse.gef.commands.Command;
 import org.eclipse.jface.action.IAction;
@@ -20,9 +21,9 @@ import org.eclipse.jface.action.IAction;
 public class ShowXYGraphToolbarAction extends AbstractXYGraphTargetAction {
 
     public void run(IAction action) {
+        DawnXYGraphModel model =  getSelectedXYGraph().getWidgetModel();
         Command command = new SetWidgetPropertyCommand(
-                getSelectedXYGraph().getWidgetModel(), XYGraphModel.PROP_SHOW_TOOLBAR,
-                !getSelectedXYGraph().getWidgetModel().isShowToolbar());
+                model, XYGraphModel.PROP_SHOW_TOOLBAR, !model.isShowToolbar());
         execute(command);
     }
 }

--- a/plugins/org.csstudio.opibuilder.widgets.dawn/src/org/csstudio/opibuilder/widgets/dawn/actions/ShowXYGraphToolbarAction.java
+++ b/plugins/org.csstudio.opibuilder.widgets.dawn/src/org/csstudio/opibuilder/widgets/dawn/actions/ShowXYGraphToolbarAction.java
@@ -1,0 +1,42 @@
+/*******************************************************************************
+ * Copyright (c) 2010 Oak Ridge National Laboratory.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ ******************************************************************************/
+package org.csstudio.opibuilder.widgets.dawn.actions;
+
+import org.csstudio.opibuilder.actions.AbstractWidgetTargetAction;
+import org.csstudio.opibuilder.commands.SetWidgetPropertyCommand;
+import org.csstudio.opibuilder.widgets.dawn.xygraph.DawnXYGraphEditPart;
+import org.csstudio.opibuilder.widgets.model.XYGraphModel;
+import org.eclipse.gef.commands.Command;
+import org.eclipse.jface.action.IAction;
+
+
+/**Show/Hide XYGraph Toolbar
+ * @author Xihui Chen
+ *
+ */
+public class ShowXYGraphToolbarAction extends AbstractWidgetTargetAction {
+
+
+
+    public void run(IAction action) {
+        Command command = new SetWidgetPropertyCommand(
+                getSelectedXYGraph().getWidgetModel(), XYGraphModel.PROP_SHOW_TOOLBAR,
+                !getSelectedXYGraph().getWidgetModel().isShowToolbar());
+        execute(command);
+
+    }
+
+    /**
+     * Gets the widget models of all currently selected EditParts.
+     *
+     * @return a list with all widget models that are currently selected
+     */
+    protected final DawnXYGraphEditPart getSelectedXYGraph() {
+        return (DawnXYGraphEditPart)selection.getFirstElement();
+    }
+}


### PR DESCRIPTION
These are copied with the exception of a cast from the corresponding actions on the opibuilder widgets:
`org.csstudio.opibuilder.widgets.actions.ShowXYGraphToolbarAction`
`org.csstudio.opibuilder.widgets.actions.ClearXYGraphActio`