### PR TITLE
Remove fa datasource from product.

### DIFF
--- a/features/org.csstudio.dls.feature/feature.xml
+++ b/features/org.csstudio.dls.feature/feature.xml
@@ -71,11 +71,4 @@
          version="0.0.0"
          unpack="false"/>
 
-   <plugin
-         id="org.diirt.datasource.fa"
-         download-size="0"
-         install-size="0"
-         version="0.0.0"
-         unpack="false"/>
-
 </feature>


### PR DESCRIPTION
It changes the order of diirt configuration meaning that the wrong
diirt configuration directory is used.

Fixing this is another matter that I'm not going to be able to do today.

@nickbattam @mfurseman 