### PR TITLE
Rearrange ordering of feature in cs-studio.product

### DIFF
--- a/repository/cs-studio.product
+++ b/repository/cs-studio.product
@@ -62,11 +62,11 @@
       <feature id="org.csstudio.core.platform.feature"/>
       <feature id="org.csstudio.core.utility.feature"/>
       <feature id="org.csstudio.core.ui.feature"/>
-      <feature id="org.csstudio.core.diirt.feature"/>
+      <feature id="org.csstudio.applications.pvmanager.diag.feature" />
       <feature id="org.csstudio.applications.opibuilder.feature"/>
       <feature id="org.csstudio.trends.databrowser2.feature"/>
       <feature id="org.csstudio.trends.databrowser2.opiwidget.feature"/>
-      <feature id="org.csstudio.applications.pvmanager.diag.feature" />
+      <feature id="org.csstudio.core.diirt.feature"/>
       <feature id="org.csstudio.dls.feature"/>
       <feature id="org.csstudio.dls.product.feature"/>
       <feature id="org.csstudio.dls.product.configuration.feature"/>


### PR DESCRIPTION
The only reason to do this is to ensure that the integration
and dls-4.2.x branches are the same.