### PR TITLE
Revert "Remove fa datasource from product."

### DIFF
--- a/features/org.csstudio.dls.feature/feature.xml
+++ b/features/org.csstudio.dls.feature/feature.xml
@@ -78,4 +78,11 @@
          version="0.0.0"
          unpack="false"/>
 
+   <plugin
+         id="org.diirt.datasource.fa"
+         download-size="0"
+         install-size="0"
+         version="0.0.0"
+         unpack="false"/>
+
 </feature>


### PR DESCRIPTION
This reverts commit 09eb5ecce905be08480f474cd42c4677f447d7b8.

Previous incompatibility with diirt configuration has been fixed.