### PR TITLE
Revert "Add antlr to DLS product dependencies."

### DIFF
--- a/plugins/org.csstudio.dls.product/META-INF/MANIFEST.MF
+++ b/plugins/org.csstudio.dls.product/META-INF/MANIFEST.MF
@@ -19,8 +19,7 @@ Require-Bundle: org.eclipse.ui,
  org.eclipse.ui.ide;bundle-version="3.6.1",
  org.csstudio.ui.menu.app;bundle-version="3.0.0",
  org.csstudio.startup.helper;bundle-version="3.1.0",
- org.csstudio.utility.product;bundle-version="1.1.0",
- org.antlr.runtime;bundle-version="[3.4.0,4.0.0)"
+ org.csstudio.utility.product;bundle-version="1.1.0"
 Bundle-ActivationPolicy: lazy
 Bundle-RequiredExecutionEnvironment: JavaSE-1.7
 Bundle-Vendor: Will Rogers <will.rogers@diamond.ac.uk>


### PR DESCRIPTION
This reverts commit 7acd22c0ca5627f7f26e8fcc598395ca3615fd66.

This was properly fixed by Eric in Diirt.