### PR TITLE
Prevent team synchronizing perspective and views from showing

### DIFF
--- a/plugins/org.csstudio.dls.product/plugin.xml
+++ b/plugins/org.csstudio.dls.product/plugin.xml
@@ -100,4 +100,23 @@
       </page>
    </extension>
 
+   <!-- Remove contributed views and perspectives by hiding them with this 'hack' -->
+   <extension
+         point="org.eclipse.ui.activities">
+      <activity id="org.csstudio.common.activity.disable" name="disable">
+      </activity>
+      <activityPatternBinding
+         activityId="org.csstudio.common.activity.disable"
+         pattern=".*/org.eclipse.team.ui.TeamSynchronizingPerspective">
+      </activityPatternBinding>
+      <activityPatternBinding
+         activityId="org.csstudio.common.activity.disable"
+         pattern=".*/org.eclipse.team.sync.views.SynchronizeView">
+      </activityPatternBinding>
+      <activityPatternBinding
+         activityId="org.csstudio.common.activity.disable"
+         pattern=".*/org.eclipse.team.ui.GenericHistoryView">
+      </activityPatternBinding>
+   </extension>
+
 </plugin>


### PR DESCRIPTION
There is a org.eclipse.team.ui plugin which is included in org.eclipse.search, a commonly used component in CS-Studio. We can't very easily remove this plugin from the build as it's required by opibuilder amongst other things, however we can hide the views and perspective it creates but nobody has any use for!

This hides the '_Team Synchronizing_' perspective, and the '_History_' and '_Synchronise_' views.