### PR TITLE
Better default perspectives and views under the Window menu - [integration]

### DIFF
--- a/plugins/org.csstudio.dls.product/plugin.xml
+++ b/plugins/org.csstudio.dls.product/plugin.xml
@@ -118,5 +118,45 @@
          pattern=".*/org.eclipse.team.ui.GenericHistoryView">
       </activityPatternBinding>
    </extension>
+   <!-- Add a common set of views and perspectives in the 'Window' menu -->
+   <extension
+         point="org.eclipse.ui.perspectiveExtensions">
+      <perspectiveExtension
+         targetID="org.csstudio.utility.product.CSStudioPerspective">
+         <perspectiveShortcut id="org.csstudio.utility.product.CSStudioPerspective"/>
+         <perspectiveShortcut id="org.csstudio.opibuilder.opieditor"/>
+         <perspectiveShortcut id="org.csstudio.opibuilder.OPIRuntime.perspective"/>
+         <perspectiveShortcut id="org.csstudio.trends.databrowser.Perspective"/>
+         <viewShortcut id="org.eclipse.ui.views.ResourceNavigator"/>
+         <viewShortcut id="org.eclipse.ui.console.ConsoleView"/>
+      </perspectiveExtension>
+      <perspectiveExtension
+         targetID="org.csstudio.opibuilder.opieditor">
+         <perspectiveShortcut id="org.csstudio.utility.product.CSStudioPerspective"/>
+         <perspectiveShortcut id="org.csstudio.opibuilder.opieditor"/>
+         <perspectiveShortcut id="org.csstudio.opibuilder.OPIRuntime.perspective"/>
+         <perspectiveShortcut id="org.csstudio.trends.databrowser.Perspective"/>
+         <viewShortcut id="org.eclipse.ui.views.ResourceNavigator"/>
+         <viewShortcut id="org.eclipse.ui.console.ConsoleView"/>
+      </perspectiveExtension>
+      <perspectiveExtension
+         targetID="org.csstudio.opibuilder.OPIRuntime.perspective">
+         <perspectiveShortcut id="org.csstudio.utility.product.CSStudioPerspective"/>
+         <perspectiveShortcut id="org.csstudio.opibuilder.opieditor"/>
+         <perspectiveShortcut id="org.csstudio.opibuilder.OPIRuntime.perspective"/>
+         <perspectiveShortcut id="org.csstudio.trends.databrowser.Perspective"/>
+         <viewShortcut id="org.eclipse.ui.views.ResourceNavigator"/>
+         <viewShortcut id="org.eclipse.ui.console.ConsoleView"/>
+      </perspectiveExtension>
+      <perspectiveExtension
+         targetID="org.csstudio.trends.databrowser.Perspective">
+         <perspectiveShortcut id="org.csstudio.utility.product.CSStudioPerspective"/>
+         <perspectiveShortcut id="org.csstudio.opibuilder.opieditor"/>
+         <perspectiveShortcut id="org.csstudio.opibuilder.OPIRuntime.perspective"/>
+         <perspectiveShortcut id="org.csstudio.trends.databrowser.Perspective"/>
+         <viewShortcut id="org.eclipse.ui.views.ResourceNavigator"/>
+         <viewShortcut id="org.eclipse.ui.console.ConsoleView"/>
+      </perspectiveExtension>
+   </extension>
 
 </plugin>


### PR DESCRIPTION
This adds a list of perspectives and views which are always shown under the Window menu, along with the 'Other...' selector.

By having a fixed order of perspectives, and showing the perspective which is currently selected in the menu, the user should feel more confident that they can navigate between perspectives and return to the current perspective. The navigator and console views are also shown by default.