### PR TITLE
Keep Standalone OPI Summary open in all perspectives - [integration]

### DIFF
--- a/plugins/org.csstudio.dls.product/plugin.xml
+++ b/plugins/org.csstudio.dls.product/plugin.xml
@@ -129,6 +129,12 @@
          <perspectiveShortcut id="org.csstudio.trends.databrowser.Perspective"/>
          <viewShortcut id="org.eclipse.ui.views.ResourceNavigator"/>
          <viewShortcut id="org.eclipse.ui.console.ConsoleView"/>
+         <view
+            id = "org.csstudio.opibuilder.opiShellSummary"
+            relative="org.eclipse.ui.views.ResourceNavigator"
+            relationship="stack"
+            closeable="false"
+            minimized="true"/>
       </perspectiveExtension>
       <perspectiveExtension
          targetID="org.csstudio.opibuilder.opieditor">
@@ -138,6 +144,12 @@
          <perspectiveShortcut id="org.csstudio.trends.databrowser.Perspective"/>
          <viewShortcut id="org.eclipse.ui.views.ResourceNavigator"/>
          <viewShortcut id="org.eclipse.ui.console.ConsoleView"/>
+         <view
+            id = "org.csstudio.opibuilder.opiShellSummary"
+            relative="org.eclipse.ui.views.ResourceNavigator"
+            relationship="stack"
+            closeable="false"
+            minimized="true"/>
       </perspectiveExtension>
       <perspectiveExtension
          targetID="org.csstudio.opibuilder.OPIRuntime.perspective">
@@ -147,6 +159,12 @@
          <perspectiveShortcut id="org.csstudio.trends.databrowser.Perspective"/>
          <viewShortcut id="org.eclipse.ui.views.ResourceNavigator"/>
          <viewShortcut id="org.eclipse.ui.console.ConsoleView"/>
+         <view
+            id = "org.csstudio.opibuilder.opiShellSummary"
+            relative="org.eclipse.ui.views.ResourceNavigator"
+            relationship="stack"
+            closeable="false"
+            minimized="true"/>
       </perspectiveExtension>
       <perspectiveExtension
          targetID="org.csstudio.trends.databrowser.Perspective">
@@ -156,6 +174,12 @@
          <perspectiveShortcut id="org.csstudio.trends.databrowser.Perspective"/>
          <viewShortcut id="org.eclipse.ui.views.ResourceNavigator"/>
          <viewShortcut id="org.eclipse.ui.console.ConsoleView"/>
+         <view
+            id = "org.csstudio.opibuilder.opiShellSummary"
+            relative="org.eclipse.ui.views.ResourceNavigator"
+            relationship="stack"
+            closeable="false"
+            minimized="true"/>
       </perspectiveExtension>
    </extension>
 


### PR DESCRIPTION
This adds the standalone OPI summary in all four default perspectives, it also isn't closeable, so you should never find yourself in a situation where your workbench window bindings have been lost from an OPI shell.

We should see how invasive this is before thinking about merging to master!