### PR TITLE
Use correct keys for default archive engines.

### DIFF
--- a/plugins/org.csstudio.dls.product.5064/plugin_customization.ini
+++ b/plugins/org.csstudio.dls.product.5064/plugin_customization.ini
@@ -63,6 +63,7 @@ org.csstudio.trends.databrowser2/urls=xnds://archiver.pri.diamond.ac.uk/archive/
 # Default data sources for newly added channels
 # Format:  <name>|<key>|<url>
 # xnds: URLs use the key. Other URLs might ignore the key.
+# Note: at Diamond 1000 is the key for the 'All' engine in both archivers.
 org.csstudio.trends.databrowser2/archives=All-(Primary Archiver)|1000|xnds://archiver.pri.diamond.ac.uk/archive/cgi/ArchiveDataServer.cgi*All-(Standby Archiver)|1000|xnds://archiver2.pri.diamond.ac.uk/archive/cgi/ArchiveDataServer.cgi
 
 # Use Autoscale axis on databrowser by default

--- a/plugins/org.csstudio.dls.product.5064/plugin_customization.ini
+++ b/plugins/org.csstudio.dls.product.5064/plugin_customization.ini
@@ -63,9 +63,9 @@ org.csstudio.trends.databrowser2/urls=xnds://archiver.pri.diamond.ac.uk/archive/
 # Default data sources for newly added channels
 # Format:  <name>|<key>|<url>
 # xnds: URLs use the key. Other URLs might ignore the key.
-org.csstudio.trends.databrowser2/archives=All-(Primary Archiver)|1|xnds://archiver.pri.diamond.ac.uk/archive/cgi/ArchiveDataServer.cgi*All-(Standby Archiver)|2|xnds://archiver2.pri.diamond.ac.uk/archive/cgi/ArchiveDataServer.cgi
+org.csstudio.trends.databrowser2/archives=All-(Primary Archiver)|1000|xnds://archiver.pri.diamond.ac.uk/archive/cgi/ArchiveDataServer.cgi*All-(Standby Archiver)|1000|xnds://archiver2.pri.diamond.ac.uk/archive/cgi/ArchiveDataServer.cgi
 
-# Use Autoscale axis on databrowser by deafult
+# Use Autoscale axis on databrowser by default
 org.csstudio.trends.databrowser2/use_auto_scale=true
 
 ## Authentication

--- a/plugins/org.csstudio.dls.product.6064/plugin_customization.ini
+++ b/plugins/org.csstudio.dls.product.6064/plugin_customization.ini
@@ -63,6 +63,7 @@ org.csstudio.trends.databrowser2/urls=xnds://archiver.pri.diamond.ac.uk/archive/
 # Default data sources for newly added channels
 # Format:  <name>|<key>|<url>
 # xnds: URLs use the key. Other URLs might ignore the key.
+# Note: at Diamond 1000 is the key for the 'All' engine in both archivers.
 org.csstudio.trends.databrowser2/archives=All-(Primary Archiver)|1000|xnds://archiver.pri.diamond.ac.uk/archive/cgi/ArchiveDataServer.cgi*All-(Standby Archiver)|1000|xnds://archiver2.pri.diamond.ac.uk/archive/cgi/ArchiveDataServer.cgi
 
 # Use Autoscale axis on databrowser by default

--- a/plugins/org.csstudio.dls.product.6064/plugin_customization.ini
+++ b/plugins/org.csstudio.dls.product.6064/plugin_customization.ini
@@ -63,9 +63,9 @@ org.csstudio.trends.databrowser2/urls=xnds://archiver.pri.diamond.ac.uk/archive/
 # Default data sources for newly added channels
 # Format:  <name>|<key>|<url>
 # xnds: URLs use the key. Other URLs might ignore the key.
-org.csstudio.trends.databrowser2/archives=All-(Primary Archiver)|1|xnds://archiver.pri.diamond.ac.uk/archive/cgi/ArchiveDataServer.cgi*All-(Standby Archiver)|2|xnds://archiver2.pri.diamond.ac.uk/archive/cgi/ArchiveDataServer.cgi
+org.csstudio.trends.databrowser2/archives=All-(Primary Archiver)|1000|xnds://archiver.pri.diamond.ac.uk/archive/cgi/ArchiveDataServer.cgi*All-(Standby Archiver)|1000|xnds://archiver2.pri.diamond.ac.uk/archive/cgi/ArchiveDataServer.cgi
 
-# Use Autoscale axis on databrowser by deafult
+# Use Autoscale axis on databrowser by default
 org.csstudio.trends.databrowser2/use_auto_scale=true
 
 ## Authentication


### PR DESCRIPTION
As it happens this didn't make any difference, but this is semantically
correct - we pick the key of the default engine, which in fact points
to the entire archive anyway.

@nickbattam 