### PR TITLE
CSS-294: Change DLS Symbol widget to update by index, not PV value

### DIFF
--- a/plugins/org.csstudio.opibuilder.widgets.edm/src/org/csstudio/opibuilder/widgets/edm/editparts/EdmSymbolEditpart.java
+++ b/plugins/org.csstudio.opibuilder.widgets.edm/src/org/csstudio/opibuilder/widgets/edm/editparts/EdmSymbolEditpart.java
@@ -24,7 +24,7 @@ public class EdmSymbolEditpart extends AbstractPVWidgetEditPart {
     protected IFigure doCreateFigure() {
         EdmSymbolModel model = (EdmSymbolModel) getModel();
         EdmSymbolFigure figure = new EdmSymbolFigure(model.getFilename());
-        figure.setSubImageSelection(0);
+        figure.setSubImageSelection(model.getImageIndex());
         figure.setSubImageWidth(model.getSubImageWidth());
         return figure;
     }
@@ -60,27 +60,13 @@ public class EdmSymbolEditpart extends AbstractPVWidgetEditPart {
         handler = new IWidgetPropertyChangeHandler() {
             public boolean handleChange(Object oldValue, Object newValue, IFigure figure) {
                 if(newValue == null) return false;
-                int selection = 0;
-                if(newValue instanceof Alarm) {
-                    // If PV value is not valid leave index as 0 (typically invalid)
-                    if(((Alarm) newValue).getAlarmSeverity() != AlarmSeverity.INVALID) {
-                        if (newValue instanceof VNumber) {
-                            selection = ((VNumber) newValue).getValue().intValue();
-                        } else if (newValue instanceof VEnum) {
-                            selection = ((VEnum) newValue).getIndex();
-                        } else {
-                            log.warning("VType " + newValue + " cannot be handled by EDM Symbol widget.");
-                        }
-                    }
-                } else {
-                    log.warning("Object " + newValue.getClass() + " cannot be handled by EDM Symbol widget.");
-                }
+                int selection = (int) newValue;
                 EdmSymbolFigure edmFigure = (EdmSymbolFigure) figure;
                 edmFigure.setSubImageSelection(selection);
                 return false;
             }
         };
-        setPropertyChangeHandler(AbstractPVWidgetModel.PROP_PVVALUE, handler);
+        setPropertyChangeHandler(EdmSymbolModel.PROP_IMAGE_INDEX, handler);
     }
 
 }

--- a/plugins/org.csstudio.opibuilder.widgets.edm/src/org/csstudio/opibuilder/widgets/edm/model/EdmSymbolModel.java
+++ b/plugins/org.csstudio.opibuilder.widgets.edm/src/org/csstudio/opibuilder/widgets/edm/model/EdmSymbolModel.java
@@ -3,6 +3,7 @@ package org.csstudio.opibuilder.widgets.edm.model;
 import org.csstudio.opibuilder.model.AbstractPVWidgetModel;
 import org.csstudio.opibuilder.properties.DoubleProperty;
 import org.csstudio.opibuilder.properties.FilePathProperty;
+import org.csstudio.opibuilder.properties.IntegerProperty;
 import org.csstudio.opibuilder.properties.WidgetPropertyCategory;
 import org.csstudio.opibuilder.util.ResourceUtil;
 import org.eclipse.core.runtime.IPath;
@@ -12,7 +13,8 @@ import org.eclipse.swt.graphics.RGB;
 public class EdmSymbolModel extends AbstractPVWidgetModel {
 
     public static final String PROP_EDM_IMAGE_FILE = "image_file";
-    public static final String PROP_SUB_IMAGE_WIDTH= "sub_image_width";
+    public static final String PROP_SUB_IMAGE_WIDTH = "sub_image_width";
+    public static final String PROP_IMAGE_INDEX = "image_index";
 
     private static final String[] FILE_EXTENSIONS = new String[] {"jpg", "jpeg", "gif", "bmp", "png"};
 
@@ -26,6 +28,7 @@ public class EdmSymbolModel extends AbstractPVWidgetModel {
     protected void configureProperties() {
         addProperty(new FilePathProperty(PROP_EDM_IMAGE_FILE, "Image File", WidgetPropertyCategory.Basic, new Path(""), FILE_EXTENSIONS));
         addProperty(new DoubleProperty(PROP_SUB_IMAGE_WIDTH, "Sub Image Width", WidgetPropertyCategory.Basic, 10));
+        addProperty(new IntegerProperty(PROP_IMAGE_INDEX, "Image Index", WidgetPropertyCategory.Basic, 0));
     }
 
     @Override
@@ -44,6 +47,10 @@ public class EdmSymbolModel extends AbstractPVWidgetModel {
     public int getSubImageWidth() {
         Double width = (Double) getProperty(PROP_SUB_IMAGE_WIDTH).getPropertyValue();
         return width.intValue();
+    }
+
+    public int getImageIndex() {
+        return (Integer) getProperty(PROP_IMAGE_INDEX).getPropertyValue();
     }
 
 }


### PR DESCRIPTION
Our typical use case for a symbol widget is to enter a PV into the PV Name field, and then set up a rule which monitors the same PV and maps that PV value to an image index to be shown. This allows us to use the right click context menu and tooltips to interact with the PV while also having custom behaviour.

The problem with the above scenario is that there is a race condition where the PV update can be applied after the rule, and the wrong image index is shown. This only seems to occur on OPI's with few widgets.

This pull request changes the widget so that the connected PV has no effect on which image is shown, and this is instead updated by an image_index property, that can then be controlled by a rule.