### PR TITLE
Refresh workspace when loading plot file from script.

### DIFF
--- a/plugins/org.csstudio.trends.databrowser2.command/META-INF/MANIFEST.MF
+++ b/plugins/org.csstudio.trends.databrowser2.command/META-INF/MANIFEST.MF
@@ -9,4 +9,5 @@ Require-Bundle: org.csstudio.trends.databrowser2;bundle-version="4.2.0",
  org.eclipse.core.runtime;bundle-version="3.11.1",
  org.csstudio.utility.singlesource,
  org.csstudio.opibuilder,
- org.apache.commons.lang;bundle-version="2.6.0"
+ org.apache.commons.lang;bundle-version="2.6.0",
+ org.eclipse.core.resources;bundle-version="3.10.1"

--- a/plugins/org.csstudio.trends.databrowser2.command/src/org/csstudio/trends/databrowser2/command/NewWindowHandler.java
+++ b/plugins/org.csstudio.trends.databrowser2.command/src/org/csstudio/trends/databrowser2/command/NewWindowHandler.java
@@ -151,12 +151,16 @@ public class NewWindowHandler extends AbstractHandler {
         IPath plotPath = null;
         if (plotfileParam != null) {
             IPath path = new Path(plotfileParam);
-            // Ensure the file is found even if externally added to the workspace.
-            refreshWorkspace();
             if (ResourceUtil.isExistingWorkspaceFile(path)) {
                 plotPath = path;
             } else {
-                LOGGER.log(Level.WARNING, "Databrowser plot file " + path + " does not exist.");
+                // Try refreshing in case the file has been externally added to the workspace.
+                refreshWorkspace();
+                if (ResourceUtil.isExistingWorkspaceFile(path)) {
+                    plotPath = path;
+                } else {
+                    LOGGER.log(Level.WARNING, "Databrowser plot file " + path + " does not exist.");
+                }
             }
         }
         return plotPath;

--- a/plugins/org.csstudio.trends.databrowser2.command/src/org/csstudio/trends/databrowser2/command/NewWindowHandler.java
+++ b/plugins/org.csstudio.trends.databrowser2.command/src/org/csstudio/trends/databrowser2/command/NewWindowHandler.java
@@ -15,6 +15,11 @@ import org.csstudio.utility.singlesource.PathEditorInput;
 import org.eclipse.core.commands.AbstractHandler;
 import org.eclipse.core.commands.ExecutionEvent;
 import org.eclipse.core.commands.ExecutionException;
+import org.eclipse.core.resources.IResource;
+import org.eclipse.core.resources.IWorkspace;
+import org.eclipse.core.resources.IWorkspaceRoot;
+import org.eclipse.core.resources.ResourcesPlugin;
+import org.eclipse.core.runtime.CoreException;
 import org.eclipse.core.runtime.IPath;
 import org.eclipse.core.runtime.Path;
 import org.eclipse.swt.widgets.Shell;
@@ -146,6 +151,8 @@ public class NewWindowHandler extends AbstractHandler {
         IPath plotPath = null;
         if (plotfileParam != null) {
             IPath path = new Path(plotfileParam);
+            // Ensure the file is found even if externally added to the workspace.
+            refreshWorkspace();
             if (ResourceUtil.isExistingWorkspaceFile(path)) {
                 plotPath = path;
             } else {
@@ -190,6 +197,20 @@ public class NewWindowHandler extends AbstractHandler {
             editor = DataBrowserEditor.createInstance();
         }
         return editor;
+    }
+
+    /**
+     * Attempt to refresh the Eclipse workspace.  If it fails, log
+     * an error.
+     */
+    private void refreshWorkspace() {
+        try {
+            IWorkspace workspace = ResourcesPlugin.getWorkspace();
+            IWorkspaceRoot root = workspace.getRoot();
+            root.refreshLocal(IResource.DEPTH_INFINITE, null);
+        } catch (CoreException e) {
+            LOGGER.log(Level.WARNING, "Workspace refresh failed unexpectedly.");
+        }
     }
 
 }


### PR DESCRIPTION
This had failed when a plot file was being manually copied into place
and the Eclipse workspace had not been refreshed.

@nickbattam