### PR TITLE
Revert "Remove unused imports"

### DIFF
--- a/plugins/org.csstudio.opibuilder.widgets.edm/src/org/csstudio/opibuilder/widgets/edm/editparts/EdmSymbolEditpart.java
+++ b/plugins/org.csstudio.opibuilder.widgets.edm/src/org/csstudio/opibuilder/widgets/edm/editparts/EdmSymbolEditpart.java
@@ -3,10 +3,15 @@ package org.csstudio.opibuilder.widgets.edm.editparts;
 import java.util.logging.Logger;
 
 import org.csstudio.opibuilder.editparts.AbstractPVWidgetEditPart;
+import org.csstudio.opibuilder.model.AbstractPVWidgetModel;
 import org.csstudio.opibuilder.properties.IWidgetPropertyChangeHandler;
 import org.csstudio.opibuilder.util.ResourceUtil;
 import org.csstudio.opibuilder.widgets.edm.figures.EdmSymbolFigure;
 import org.csstudio.opibuilder.widgets.edm.model.EdmSymbolModel;
+import org.diirt.vtype.Alarm;
+import org.diirt.vtype.AlarmSeverity;
+import org.diirt.vtype.VEnum;
+import org.diirt.vtype.VNumber;
 import org.eclipse.core.runtime.IPath;
 import org.eclipse.draw2d.IFigure;
 


### PR DESCRIPTION
This reverts commit 1ab8cf934ee27dd9f93a6edc95fc87a3c41059b0.

Incorrect copy of checkstyle branch (#166) onto master. EdmSymbolEditpart has changed between 4.3 and 4.4.