### PR TITLE
Ensure perspective names are shown in the UI.

### DIFF
--- a/plugins/org.csstudio.dls.product.common/plugin_customization.ini
+++ b/plugins/org.csstudio.dls.product.common/plugin_customization.ini
@@ -35,6 +35,8 @@ org.csstudio.logging/file_pattern=%t/cs-studio-%u.log
 
 org.eclipse.ui/SHOW_PROGRESS_ON_STARTUP = true
 org.eclipse.ui/defaultPerspectiveId=org.csstudio.trends.databrowser.Perspective
+# show the perspective names in the UI, rather than just icons
+org.eclipse.ui/SHOW_TEXT_ON_PERSPECTIVE_BAR=true
 
 # Refresh workspace automatically
 org.eclipse.core.resources/refresh.lightweight.enabled=true


### PR DESCRIPTION
They were removed by default in Eclipse Neon. @nickbattam 