### PR TITLE
javax.mail build issues

### DIFF
--- a/features/org.csstudio.dls.feature/feature.xml
+++ b/features/org.csstudio.dls.feature/feature.xml
@@ -17,17 +17,6 @@
       Eclipse Public License.
    </license>
 
-   <!-- This plugin is required by opibuilder but doesn't seem to be
-        included anywhere. When building with the Dawn p2 repository
-        enabled this plugin is no longer built into the final
-        product, so we work around this by including it here. -->
-   <plugin
-         id="com.sun.mail.javax.mail"
-         download-size="0"
-         install-size="0"
-         version="0.0.0"
-         unpack="false"/>
-
    <plugin
          id="org.csstudio.logbook.dls"
          download-size="0"

--- a/plugins/org.csstudio.trends.databrowser2.command/META-INF/MANIFEST.MF
+++ b/plugins/org.csstudio.trends.databrowser2.command/META-INF/MANIFEST.MF
@@ -11,3 +11,4 @@ Require-Bundle: org.csstudio.trends.databrowser2;bundle-version="4.2.0",
  org.csstudio.opibuilder,
  org.apache.commons.lang;bundle-version="2.6.0",
  org.eclipse.core.resources;bundle-version="3.10.1"
+Import-Package: javax.mail


### PR DESCRIPTION
@willrogers This fixes the missing javax.mail error in the offline build. I have successfully run an offline build with this patch.

Removing javax.mail from feature and adding it as an explicit Import doesn't look like the right approach; it's patching an issue rather than understanding why the databrowser2 dependence on javax.mail isn't being managed correctly when we pull it from applications.