### PR TITLE
Mmux enabling

### DIFF
--- a/plugins/org.csstudio.opibuilder.widgets.edm/src/org/csstudio/opibuilder/widgets/edm/editparts/MenuMuxEditPart.java
+++ b/plugins/org.csstudio.opibuilder.widgets.edm/src/org/csstudio/opibuilder/widgets/edm/editparts/MenuMuxEditPart.java
@@ -4,6 +4,7 @@ import java.util.List;
 
 import org.csstudio.opibuilder.editparts.AbstractPVWidgetEditPart;
 import org.csstudio.opibuilder.editparts.ExecutionMode;
+import org.csstudio.opibuilder.model.AbstractPVWidgetModel;
 import org.csstudio.opibuilder.model.AbstractWidgetModel;
 import org.csstudio.opibuilder.properties.IWidgetPropertyChangeHandler;
 import org.csstudio.opibuilder.widgets.edm.figures.MenuMuxFigure;
@@ -54,6 +55,8 @@ public final class MenuMuxEditPart extends AbstractPVWidgetEditPart {
         combo.addSelectionListener(comboSelectionListener);
 
         updateCombo(model.getItems());
+
+        markAsControlPV(AbstractPVWidgetModel.PROP_PVNAME, AbstractPVWidgetModel.PROP_PVVALUE);
 
         return comboFigure;
     }

--- a/plugins/org.csstudio.opibuilder.widgets.edm/src/org/csstudio/opibuilder/widgets/edm/editparts/MenuMuxEditPart.java
+++ b/plugins/org.csstudio.opibuilder.widgets.edm/src/org/csstudio/opibuilder/widgets/edm/editparts/MenuMuxEditPart.java
@@ -155,28 +155,23 @@ public final class MenuMuxEditPart extends AbstractPVWidgetEditPart {
      * to connection and writePermission changes
      */
     private void createListeners() {
-
         if(getExecutionMode() == ExecutionMode.RUN_MODE){
             MenuMuxModel model = getWidgetModel();
-            WidgetPVListener pvListener;
-
-            IPV pv = delegate.getPV();
-            if (pv != null) {
-                pvListener = new WidgetPVListener();
-                pv.addListener(pvListener);
-                targetPVsListenerMap.put(pv, pvListener);
-            }
-
+            // control PV
+            addListener(delegate.getPV());
+            // target PVs
             for (int setIndex = 0; setIndex < model.getNumSets(); setIndex++) {
                 String propId = MenuMuxModel.makePropId(MuxProperty.TARGET.propIDPre, setIndex);
-
-                pv = delegate.getPV(propId);
-                if (pv != null) {
-                    pvListener = new WidgetPVListener();
-                    pv.addListener(pvListener);
-                    targetPVsListenerMap.put(pv, pvListener);
-                }
+                addListener(delegate.getPV(propId));
             }
+        }
+    }
+
+    private void addListener(IPV pv) {
+        if (pv != null) {
+            WidgetPVListener pvListener = new WidgetPVListener();
+            pv.addListener(pvListener);
+            targetPVsListenerMap.put(pv, pvListener);
         }
     }
 

--- a/plugins/org.csstudio.opibuilder.widgets.edm/src/org/csstudio/opibuilder/widgets/edm/editparts/MenuMuxEditPart.java
+++ b/plugins/org.csstudio.opibuilder.widgets.edm/src/org/csstudio/opibuilder/widgets/edm/editparts/MenuMuxEditPart.java
@@ -169,12 +169,13 @@ public final class MenuMuxEditPart extends AbstractPVWidgetEditPart {
 
             for (int setIndex = 0; setIndex < model.getNumSets(); setIndex++) {
                 String propId = MenuMuxModel.makePropId(MuxProperty.TARGET.propIDPre, setIndex);
-                pvListener = new WidgetPVListener();
 
                 pv = delegate.getPV(propId);
-                pv.addListener(pvListener);
-                // local cache to clean on deactivation
-                targetPVsListenerMap.put(pv, pvListener);
+                if (pv != null) {
+                    pvListener = new WidgetPVListener();
+                    pv.addListener(pvListener);
+                    targetPVsListenerMap.put(pv, pvListener);
+                }
             }
         }
     }

--- a/plugins/org.csstudio.opibuilder.widgets.edm/src/org/csstudio/opibuilder/widgets/edm/figures/MenuMuxFigure.java
+++ b/plugins/org.csstudio.opibuilder.widgets.edm/src/org/csstudio/opibuilder/widgets/edm/figures/MenuMuxFigure.java
@@ -9,6 +9,7 @@ package org.csstudio.opibuilder.widgets.edm.figures;
 
 
 import org.csstudio.opibuilder.editparts.AbstractBaseEditPart;
+import org.csstudio.opibuilder.model.AbstractWidgetModel;
 import org.csstudio.opibuilder.widgets.figures.AbstractSWTWidgetFigure;
 import org.csstudio.ui.util.CustomMediaFactory;
 import org.eclipse.draw2d.Graphics;
@@ -52,7 +53,7 @@ public class MenuMuxFigure extends AbstractSWTWidgetFigure<Combo> {
 
     @Override
     protected Combo createSWTWidget(Composite parent, int style) {
-        combo= new Combo(parent, SWT.DROP_DOWN | SWT.READ_ONLY);
+        combo = new Combo(parent, SWT.DROP_DOWN | SWT.READ_ONLY);
         return combo;
     }
 
@@ -76,6 +77,18 @@ public class MenuMuxFigure extends AbstractSWTWidgetFigure<Combo> {
             graphics.setForegroundColor(DARK_GRAY_COLOR);
             graphics.drawRectangle(new Rectangle(clientArea.getLocation(),
                     clientArea.getSize().shrink(1, 1)));
+        }
+    }
+
+    @Override
+    public void setEnabled(boolean value) {
+        super.setEnabled(value);
+        if (value) {
+            setForegroundColor(
+                    editPart.getWidgetModel().getSWTColorFromColorProperty(
+                            AbstractWidgetModel.PROP_COLOR_FOREGROUND));
+        } else {
+            setForegroundColor(DARK_GRAY_COLOR);
         }
     }
 

--- a/plugins/org.csstudio.opibuilder.widgets.edm/src/org/csstudio/opibuilder/widgets/edm/model/MenuMuxModel.java
+++ b/plugins/org.csstudio.opibuilder.widgets.edm/src/org/csstudio/opibuilder/widgets/edm/model/MenuMuxModel.java
@@ -7,8 +7,8 @@ import org.csstudio.opibuilder.properties.IntegerProperty;
 import org.csstudio.opibuilder.properties.NameDefinedCategory;
 import org.csstudio.opibuilder.properties.PVNameProperty;
 import org.csstudio.opibuilder.properties.PVValueProperty;
-import org.csstudio.opibuilder.properties.StringProperty;
 import org.csstudio.opibuilder.properties.StringListProperty;
+import org.csstudio.opibuilder.properties.StringProperty;
 import org.csstudio.opibuilder.properties.WidgetPropertyCategory;
 import org.csstudio.opibuilder.widgets.model.ComboModel;
 import org.eclipse.swt.graphics.RGB;
@@ -60,7 +60,7 @@ public class MenuMuxModel extends ComboModel {
                 PROP_ITEMS, "Items", WidgetPropertyCategory.Misc, new ArrayList<String>()));
 
         addProperty(new IntegerProperty(
-                PROP_NUM_SETS, "Number of value sets", WidgetPropertyCategory.Misc, 1, 1, MAX_SETS));
+                PROP_NUM_SETS, "Number of value sets", WidgetPropertyCategory.Misc, 1, 0, MAX_SETS));
 
         addProperty(new StringProperty(
                 PROP_INITIAL_STATE, "Initial State", WidgetPropertyCategory.Misc, ""));


### PR DESCRIPTION
@willrogers, @mfurseman  MenuMux is now disabled if any of the attached PVs (target or controlPV) are read-only and updates ALL target PVs when the control PV (PV_NAME) is updated.