### PR TITLE
Don't show OPIShellSummary in OPIRuntime perspective.

### DIFF
--- a/plugins/org.csstudio.dls.product.common/plugin.xml
+++ b/plugins/org.csstudio.dls.product.common/plugin.xml
@@ -86,11 +86,14 @@
          <perspectiveShortcut id="org.csstudio.trends.databrowser.Perspective"/>
          <viewShortcut id="org.eclipse.ui.views.ResourceNavigator"/>
          <viewShortcut id="org.eclipse.ui.console.ConsoleView"/>
+         <!-- When opening OPIRuntime perspective we don't want unnecessary
+              clutter, so this view is not set as visible. -->
          <view
             id = "org.csstudio.opibuilder.opiShellSummary"
             relative="org.eclipse.ui.views.ResourceNavigator"
             relationship="stack"
             closeable="false"
+            visible="false"
             minimized="true"/>
       </perspectiveExtension>
       <perspectiveExtension


### PR DESCRIPTION
@nickbattam @mfurseman this means that if you open a screen in a new workbench window, all you get is that screen. The right-clicks seem to work, but I know it is possible to lose the right-clicks sometimes, I just haven't managed to pinpoint when.