### PR TITLE
Make sure we specify all vm args

### DIFF
--- a/features/org.csstudio.dls.product.feature/rootfiles/css.sh
+++ b/features/org.csstudio.dls.product.feature/rootfiles/css.sh
@@ -190,4 +190,4 @@ fi
 
 # Echo subsequent commands for debugging.
 set -x
-$CSSTUDIO $plugin_preferences $local_links_args $dev_args $data_args $xmi_args --launcher.openFile "$runfile $macros_escaped $links_escaped" $vm_args
+$CSSTUDIO --launcher.appendVmargs $plugin_preferences $local_links_args $dev_args $data_args $xmi_args --launcher.openFile "$runfile $macros_escaped $links_escaped" $vm_args

--- a/features/org.csstudio.dls.product.feature/rootfiles/css.sh
+++ b/features/org.csstudio.dls.product.feature/rootfiles/css.sh
@@ -72,19 +72,6 @@ dev=false
 opishell=false
 port=5064
 
-# Default values for VM arguments
-# Despite being able to specify these in the product, providing any
-# command line arguments overrides all options set there, so we have
-# to set them all here.
-vm_args="-vmargs " \
-    "-Xmx3072m " \
-    "-Xms256m " \
-    "-Dosgi.requiredJavaVersion=1.8 " \
-    "-Dorg.osgi.framework.bundle.parent=ext " \
-    "-Dosgi.framework.extensions=org.eclipse.fx.osgi " \
-    "-Dosgi.checkConfiguration=true " \
-    "-Dorg.osgi.framework.system.packages.extra=sun.misc "
-
 while getopts "w:do:p:n:x:m:sl:c" opt; do
     case $opt in
         w)
@@ -198,7 +185,7 @@ local_links_args="-share_link $personal_location=/CSS/$USER"
 # This applies only for the initial launch, which is where we may
 # need this information.
 if [[ $is_nwsfile = true ]]; then
-    vm_args="${vm_args} -Dnws_file"
+    vm_args="-vmargs -Dnws_file"
 fi
 
 # Echo subsequent commands for debugging.

--- a/repository/cs-studio.product
+++ b/repository/cs-studio.product
@@ -16,6 +16,13 @@
    <launcherArgs>
       <programArgs>--launcher.GTK_version 2
       </programArgs>
+      <vmArgs>-Xmx3072m
+-Xms256m
+-Dosgi.requiredJavaVersion=1.8
+-Dorg.osgi.framework.bundle.parent=ext
+-Dosgi.framework.extensions=org.eclipse.fx.osgi
+-Dosgi.checkConfiguration=true
+-Dorg.osgi.framework.system.packages.extra=sun.misc</vmArgs>
       <vmArgsMac>-XstartOnFirstThread -Dorg.eclipse.swt.internal.carbon.smallFonts</vmArgsMac>
    </launcherArgs>
 


### PR DESCRIPTION
This changes the previous build-fixes branch to use the --launcher.appendVmargs, instead of just moving them all out into the css.sh wrapper script.