### PR TITLE
remove eclipse 3.3 update site in preferences dialog

### DIFF
--- a/repository/cs-studio.p2.inf
+++ b/repository/cs-studio.p2.inf
@@ -1,6 +1,4 @@
 instructions.configure=\
-  org.eclipse.equinox.p2.touchpoint.eclipse.addRepository(type:0,name:CS-Studio update site,location:http${#58}//download.controlsystemstudio.org/updates/3.3,enabled:true);\
-  org.eclipse.equinox.p2.touchpoint.eclipse.addRepository(type:1,name:CS-Studio update site,location:http${#58}//download.controlsystemstudio.org/updates/3.3,enabled:true);\
   org.eclipse.equinox.p2.touchpoint.natives.mkdir(path:${installFolder}/logs);\
   
 #  setProgramProperty(propName:org.eclipse.equinox.p2.cache,propValue:@user.home/p2Cache);\


### PR DESCRIPTION
Gets rid of the preferences update site.