### PR TITLE
Css582 screen launching

### DIFF
--- a/features/org.csstudio.dls.product.feature/rootfiles/css.sh
+++ b/features/org.csstudio.dls.product.feature/rootfiles/css.sh
@@ -202,7 +202,15 @@ eclipse_args="--launcher.appendVmargs -clearPersistedState"
 # need to do this after any use of that variable.
 module load controls-java/11-0-9
 
+COMMAND_PREFIX=""
+# If CSS is already running:
+if gdbus introspect --session --dest org.eclipse.swt.cs-studio --object-path /org/eclipse/swt &>/dev/null; then
+    # Fix error that appears if parent terminal of CSS main window is closed
+    unset GNOME_TERMINAL_SCREEN
+    # Use gnome-terminal to keep any new screen on the current desktop workspace
+    COMMAND_PREFIX="gnome-terminal --hide-menubar --geometry=0x0 --"
+fi
+
 # Echo subsequent commands for debugging.
 set -x
-# Use gnome-terminal to keep any new screen on the current desktop workspace
-gnome-terminal --hide-menubar --geometry=0x0 -- $CSSTUDIO $eclipse_args $plugin_preferences $local_links_args $dev_args $data_args $xmi_args --launcher.openFile "$runfile" $vm_args
+$COMMAND_PREFIX $CSSTUDIO $eclipse_args $plugin_preferences $local_links_args $dev_args $data_args $xmi_args --launcher.openFile "$runfile" $vm_args

--- a/features/org.csstudio.dls.product.feature/rootfiles/css.sh
+++ b/features/org.csstudio.dls.product.feature/rootfiles/css.sh
@@ -204,4 +204,5 @@ module load controls-java/11-0-9
 
 # Echo subsequent commands for debugging.
 set -x
-$CSSTUDIO $eclipse_args $plugin_preferences $local_links_args $dev_args $data_args $xmi_args --launcher.openFile "$runfile" $vm_args
+# Use gnome-terminal to keep any new screen on the current desktop workspace
+gnome-terminal --hide-menubar --geometry=0x0 -- $CSSTUDIO $eclipse_args $plugin_preferences $local_links_args $dev_args $data_args $xmi_args --launcher.openFile "$runfile" $vm_args


### PR DESCRIPTION
Use gdbus to figure out if cs-studio is running in the current session. Use gnome-terminal only if so, to prevent unwanted workspace switches.