### PR TITLE
Adding a default property to configure diirt to subscribe to property updates

### DIFF
--- a/plugins/org.csstudio.dls.product.common/plugin_customization.ini
+++ b/plugins/org.csstudio.dls.product.common/plugin_customization.ini
@@ -106,6 +106,7 @@ org.csstudio.diirt.util.core.preferences/diirt.ca.server.port=5064
 org.csstudio.diirt.util.core.preferences/diirt.ca.repeater.port=5065
 org.csstudio.diirt.util.core.preferences/diirt.ca.addr.list=
 org.csstudio.diirt.util.core.preferences/diirt.ca.max.array.size=5000000
+org.csstudio.diirt.util.core.preferences/diirt.ca.dbe.property.supported=true
 
 #
 # IDE sometimes adds stuff below this line...


### PR DESCRIPTION
 This will allow CS-Studio to subscribe to property updates in the IoC and pick up runtime changes. This relates to an issue discovered where a dropdown menu populated with enum values did not update as the enum labels changed at run time. 
This change will support getting property updates by default in the DLS instance of CS-Studio.