### PR TITLE
Update diirt repo to use Diamond p2 mirror

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -27,7 +27,7 @@
     <tycho-extras.version>${tycho.version}</tycho-extras.version>
     <cs-studio.version>4.7</cs-studio.version>
     <diirt.version>3.1.7</diirt.version>
-    <diirt.download.root>http://diirt.download.controlsystemstudio.org</diirt.download.root>
+    <diirt.download.root>https://alfred.diamond.ac.uk/sites/diirt.download.controlsystemstudio.org</diirt.download.root>
     <cs-studio.update.url>http://download.controlsystemstudio.org/updates/${cs-studio.version}</cs-studio.update.url>
     <eclipse-site>http://download.eclipse.org/releases/2020-12</eclipse-site>
     <eclipse-update-site>http://download.eclipse.org/eclipse/updates/4.18</eclipse-update-site>
@@ -108,7 +108,7 @@
         </repository>
           <repository>
           <id>diirt</id>
-          <url>http://diirt.download.controlsystemstudio.org/diirt/${diirt.version}</url>
+          <url>https://alfred.diamond.ac.uk/sites/diirt.download.controlsystemstudio.org/diirt/${diirt.version}</url>
           <layout>p2</layout>
         </repository>
       </repositories>


### PR DESCRIPTION
The URL for CSS dependency packages has been taken offline. This PR replaces the URL for diirt with an internal P2 mirror to allow CSS builds to complete in Jenkins.

This code has been tested in Jenkins and the integration build jobs now pass: https://jenkins.diamond.ac.uk/view/CS-Studio/

Old Link: http://diirt.download.controlsystemstudio.org/diirt/3.1.7
New Link: https://alfred.diamond.ac.uk/sites/diirt.download.controlsystemstudio.org/diirt/3.1.7
