### PR TITLE
Add DLS specific properties to CS-Studio ini file

### DIFF
--- a/repository/cs-studio.product
+++ b/repository/cs-studio.product
@@ -23,7 +23,8 @@
 -Dosgi.checkConfiguration=true
 -Djavax.xml.bind.JAXBContextFactory=com.sun.xml.bind.v2.ContextFactory
 -Dorg.osgi.framework.system.packages.extra=sun.misc
--Djdk.util.zip.disableZip64ExtraFieldValidation=true</vmArgs>
+-Djdk.util.zip.disableZip64ExtraFieldValidation=true
+-Dcom.cosylab.epics.caj.impl.CAConnector.socket_connect_timeout=3</vmArgs>
       <vmArgsMac>-XstartOnFirstThread -Dorg.eclipse.swt.internal.carbon.smallFonts</vmArgsMac>
    </launcherArgs>
 

--- a/repository/cs-studio.product
+++ b/repository/cs-studio.product
@@ -22,7 +22,8 @@
 -Dosgi.framework.extensions=org.eclipse.fx.osgi
 -Dosgi.checkConfiguration=true
 -Djavax.xml.bind.JAXBContextFactory=com.sun.xml.bind.v2.ContextFactory
--Dorg.osgi.framework.system.packages.extra=sun.misc</vmArgs>
+-Dorg.osgi.framework.system.packages.extra=sun.misc
+-Djdk.util.zip.disableZip64ExtraFieldValidation=true</vmArgs>
       <vmArgsMac>-XstartOnFirstThread -Dorg.eclipse.swt.internal.carbon.smallFonts</vmArgsMac>
    </launcherArgs>
 


### PR DESCRIPTION
Two properties have been added for CSS startup:
- Property to disable validation of JAR files. This check is performed in later versions of Java and fails for the jython-standalone.jar plugin that CSS depends on. This causes runtime issues when using CSS. The later version of the jython-standalone package also do not pass these checks therefore the only workaround to ensure CSS works on later versions of Java is to set this property.
- Property to set the socket connection timeout when establishing a TCP connection. This is used with the latest version of the JCA plugin (2.4.10), which has just been pulled into the latest CSS build config. For DLS we want this timeout to be 3 secs.